### PR TITLE
Fix environment default and createId implementation

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   PORT: z.coerce.number().default(3000),
-  DATABASE_URL: z.string().default('hr_recruitment.db'),
+  DATABASE_URL: z
+    .string()
+    .default(
+      'postgresql://postgres:postgres@localhost:5432/hr_recruitment'
+    ),
   
   // Authentication
   JWT_SECRET: z.string().default('your-super-secret-jwt-key-change-this-in-production'),

--- a/src/modules/jobs/jobs.schema.ts
+++ b/src/modules/jobs/jobs.schema.ts
@@ -1,5 +1,5 @@
 import { pgTable, text, integer, timestamp, json, varchar } from 'drizzle-orm/pg-core';
-import { createId } from '@paralleldrive/cuid2';
+import { createId } from '@/shared/utils/createId';
 import { JobStatus, JobType } from './jobs.types';
 
 export const jobs = pgTable('jobs', {

--- a/src/modules/jobs/jobs.service.ts
+++ b/src/modules/jobs/jobs.service.ts
@@ -3,7 +3,7 @@ import { EventBus } from '@/shared/infrastructure/events';
 import type { Job } from './jobs.schema';
 import type { CreateJobInput, UpdateJobInput } from './jobs.types';
 import { JobStatus } from './jobs.types';
-import { createId } from '@paralleldrive/cuid2';
+import { createId } from '@/shared/utils/createId';
 
 export class JobsService {
   constructor(

--- a/src/shared/utils/createId.ts
+++ b/src/shared/utils/createId.ts
@@ -1,0 +1,5 @@
+import { randomUUID } from 'crypto';
+
+export function createId(): string {
+  return randomUUID();
+}


### PR DESCRIPTION
## Summary
- use a postgres URL as the default `DATABASE_URL`
- replace `@paralleldrive/cuid2` with a small internal helper

## Testing
- `bun test` *(fails: Cannot find package 'zod')*

------
https://chatgpt.com/codex/tasks/task_e_6861b4ece8848327858c97e70119c545