### PR TITLE
feat(config): add rate limit env vars

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -31,7 +31,11 @@ const envSchema = z.object({
   
   // CORS
   CORS_ORIGIN: z.string().default('http://localhost:3001,http://localhost:3000'),
-  
+
+  // Rate limiting
+  RATE_LIMIT_WINDOW: z.string().default('15m'),
+  RATE_LIMIT_MAX: z.coerce.number().default(100),
+
   // Logging
   LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   LOG_FORMAT: z.enum(['pretty', 'json']).default('pretty'),


### PR DESCRIPTION
## Summary
- support rate limit environment variables

## Testing
- `bun test` *(fails: Cannot find package 'zod')*


------
https://chatgpt.com/codex/tasks/task_e_6861b95652cc832793dab11b435097e5